### PR TITLE
Import description and settings from wpforms

### DIFF
--- a/includes/importer/class-importer-abstract.php
+++ b/includes/importer/class-importer-abstract.php
@@ -760,7 +760,7 @@ abstract class WeForms_Importer_Abstract {
                     'middle_name' => $args['middle_name'],
                     'last_name'   => $args['last_name'],
                     'hide_subs'   => false,
-                    'help'        => $args['description'],
+                    'help'        => $args['help'],
                     'css'         => $args['css_class'],
                     'wpuf_cond'   => $this->conditionals,
                 );

--- a/includes/importer/class-importer-wpforms.php
+++ b/includes/importer/class-importer-wpforms.php
@@ -76,7 +76,7 @@ class WeForms_Importer_WPForms extends WeForms_Importer_Abstract {
 
         $form_notifications = array(
             array(
-                'active'      => $settings['notification_enable'] ? true : false,
+                'active'      => $parsed['settings']['notification_enable'] ? true : false,
                 'name'        => 'Admin Notification',
                 'subject'     => $notification['subject'],
                 'to'          => $notification['email'],
@@ -185,7 +185,7 @@ class WeForms_Importer_WPForms extends WeForms_Importer_Abstract {
         $settings = $parsed['settings'];
 
         // Settings mapping
-        switch ( $settings['confirmation_type'] ) {
+        switch ( $settings['confirmations'][1]['type'] ) {
             case 'redirect':
                 $redirect_to = 'url';
                 break;
@@ -201,9 +201,9 @@ class WeForms_Importer_WPForms extends WeForms_Importer_Abstract {
         }
 
         $form_settings = wp_parse_args( array(
-            'message'     => $settings['confirmation_message'],
-            'page_id'     => $settings['confirmation_page'],
-            'url'         => $settings['confirmation_redirect'],
+            'message'     => $settings['confirmations'][1]['message'],
+            'page_id'     => $settings['confirmations'][1]['page'],
+            'url'         => $settings['confirmations'][1]['redirect'],
             'submit_text' => $settings['submit_text'],
             'redirect_to' => $redirect_to,
         ), $default );


### PR DESCRIPTION
This PR includes these fixes.

- [x] Description import from name field of any forms, `$args['description']` is undefined should've been `$args['help']`.

- [x]  Settings import from WPForms.